### PR TITLE
Add built-in tree command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "one-terminal",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "One \"fake\" terminal to rule them all! A React terminal component.",
   "exports": {
     ".": {

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -209,51 +209,83 @@ export function useTerminalEngine(
       }
 
       if (cmd === "tree") {
-        const rawTarget = args[0] ?? ".";
-
-        const targetPath = resolvePath(rawTarget);
+        const target = args[0] ?? ".";
+        const targetPath = resolvePath(target);
         const node = getNodeAt(targetPath);
 
         if (!node) {
-          return makeEntry(`tree: cannot access '${rawTarget}': No such file or directory`);
+          return makeEntry(`tree: cannot access '${target}': No such file or directory`);
         }
 
         if (isFile(node)) {
-          return makeEntry(rawTarget);
+          return makeEntry(target);
         }
 
-        const lines: string[] = [];
-
-        const walk = (
-          cur: DirectoryNode,
-          name: string,
-          depthLevel: number,
-          prefix: string,
-          isLast: boolean
-        ) => {
-          const connector = depthLevel === 0 ? name : `${isLast ? "└── " : "├── "}${name}`;
-          lines.push(prefix + connector);
-
-          const entries = Object.entries(cur.entries)
-            .sort(([a], [b]) => a.localeCompare(b));
-
-          entries.forEach(([childName, childNode], idx) => {
-            const last = idx === entries.length - 1;
-            if (isDirectory(childNode)) {
-              const newPrefix = prefix + (depthLevel === 0 ? "" : isLast ? "    " : "│   ");
-              walk(childNode as DirectoryNode, childName, depthLevel + 1, newPrefix, last);
-            } else {
-              const childLine = prefix + (depthLevel === 0 ? "" : isLast ? "    " : "│   ") +
-                `${last ? "└── " : "├── "}${childName}`;
-              lines.push(childLine);
-            }
-          });
+        type TreeItem = {
+          label: string;
+          isDirectory: boolean;
+          branch?: TreeItem[];
         };
 
-        const rootName = rawTarget === "." ? "." : rawTarget;
-        walk(node as DirectoryNode, rootName, 0, "", true);
+        function buildTreeStruct(dirNode: DirectoryNode, label: string): TreeItem {
+          const entries = Object.entries(dirNode.entries).sort(([a], [b]) => a.localeCompare(b));
+          const branches: TreeItem[] = [];
 
-        return makeEntry(lines.join("\n"));
+          for (const [entryName, entryNode] of entries) {
+            if (isDirectory(entryNode)) {
+              branches.push(buildTreeStruct(entryNode as DirectoryNode, entryName));
+            } else {
+              branches.push({ label: entryName, isDirectory: false });
+            }
+          }
+
+          return { label, isDirectory: true, branch: branches };
+        }
+
+        function buildTreeString(item: TreeItem, indent = "", isRootNode = true, isTail = true): string[] {
+          const output: string[] = [];
+
+          if (isRootNode) {
+            output.push(item.label);
+          } else {
+            let branch = "├── ";
+            if (isTail) {
+              branch = "└── ";
+            }
+            output.push(indent + branch + item.label);
+          }
+
+          if (!item.branch || item.branch.length === 0) {
+            return output;
+          }
+
+          const branchCount = item.branch.length;
+          for (let i = 0; i < branchCount; i++) {
+            const branch = item.branch[i];
+            const isEndBranch = i === branchCount - 1;
+
+            let continuation = "";
+            if (isRootNode) {
+              continuation = "";
+            } else {
+              if (isTail) {
+                continuation = "    ";
+              } else {
+                continuation = "│   ";
+              }
+            }
+
+            const branchIndent = indent + continuation;
+            const branchLines = buildTreeString(branch, branchIndent, false, isEndBranch);
+            output.push(...branchLines);
+          }
+
+          return output;
+        }
+
+        const tree = buildTreeStruct(node as DirectoryNode, target);
+        const outputLines = buildTreeString(tree);
+        return makeEntry(outputLines.join("\n"));
       }
 
       if (cmd === "cd") {

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -17,7 +17,7 @@ import type {
 } from "./types";
 
 // Built-in commands
-const BUILTIN_COMMANDS = ["help", "ls", "cd", "cat", "echo", "pwd", "clear"];
+const BUILTIN_COMMANDS = ["help", "ls", "tree", "cd", "cat", "echo", "pwd", "clear"];
 
 function isDirectory(node: FSNode | undefined | null): node is DirectoryNode {
   return !!node && typeof node === "object" && node.kind === "directory";
@@ -74,6 +74,7 @@ function getPathCompletionScopeForCommand(
   if (cmd === "cd") return "directories";
   if (cmd === "cat") return "files";
   if (cmd === "ls") return "any";
+  if (cmd === "tree") return "directories";
 
   const def: ExtraCommandDefinition | undefined =
     extraCommands && extraCommands[cmd];
@@ -205,6 +206,54 @@ export function useTerminalEngine(
         }
 
         return makeEntry("(unknown node type)");
+      }
+
+      if (cmd === "tree") {
+        const rawTarget = args[0] ?? ".";
+
+        const targetPath = resolvePath(rawTarget);
+        const node = getNodeAt(targetPath);
+
+        if (!node) {
+          return makeEntry(`tree: cannot access '${rawTarget}': No such file or directory`);
+        }
+
+        if (isFile(node)) {
+          return makeEntry(rawTarget);
+        }
+
+        const lines: string[] = [];
+
+        const walk = (
+          cur: DirectoryNode,
+          name: string,
+          depthLevel: number,
+          prefix: string,
+          isLast: boolean
+        ) => {
+          const connector = depthLevel === 0 ? name : `${isLast ? "└── " : "├── "}${name}`;
+          lines.push(prefix + connector);
+
+          const entries = Object.entries(cur.entries)
+            .sort(([a], [b]) => a.localeCompare(b));
+
+          entries.forEach(([childName, childNode], idx) => {
+            const last = idx === entries.length - 1;
+            if (isDirectory(childNode)) {
+              const newPrefix = prefix + (depthLevel === 0 ? "" : isLast ? "    " : "│   ");
+              walk(childNode as DirectoryNode, childName, depthLevel + 1, newPrefix, last);
+            } else {
+              const childLine = prefix + (depthLevel === 0 ? "" : isLast ? "    " : "│   ") +
+                `${last ? "└── " : "├── "}${childName}`;
+              lines.push(childLine);
+            }
+          });
+        };
+
+        const rootName = rawTarget === "." ? "." : rawTarget;
+        walk(node as DirectoryNode, rootName, 0, "", true);
+
+        return makeEntry(lines.join("\n"));
       }
 
       if (cmd === "cd") {

--- a/website/src/components/sections/Commands.tsx
+++ b/website/src/components/sections/Commands.tsx
@@ -1,9 +1,10 @@
-import { Terminal, Folder, FileText, MapPin, MessageSquare, Trash2, HelpCircle, ChevronRight } from 'lucide-react';
+import { Terminal, FolderTree, Folder, FileText, MapPin, MessageSquare, Trash2, HelpCircle, ChevronRight } from 'lucide-react';
 
 const commands = [
   { name: 'help', description: 'Display available commands', icon: HelpCircle, color: 'text-terminal-cyan' },
   { name: 'cd', description: 'Navigate between directories', icon: ChevronRight, color: 'text-terminal-green' },
   { name: 'ls', description: 'List directory contents', icon: Folder, color: 'text-terminal-yellow' },
+  { name: 'tree', description: 'Display directory structure in a tree-like format', icon: FolderTree, color: 'text-terminal-green' },
   { name: 'cat', description: 'Display file contents', icon: FileText, color: 'text-terminal-purple' },
   { name: 'pwd', description: 'Print working directory', icon: MapPin, color: 'text-terminal-cyan' },
   { name: 'echo', description: 'Output text to terminal', icon: MessageSquare, color: 'text-terminal-green' },


### PR DESCRIPTION
<img width="1542" height="824" alt="CleanShot 2026-01-30 at 14 17 20" src="https://github.com/user-attachments/assets/07229ebf-4109-4c15-9488-d956017f4574" />
<img width="1524" height="812" alt="CleanShot 2026-01-30 at 14 17 49" src="https://github.com/user-attachments/assets/75a8610f-2b73-4f0a-9fea-fee053e28664" />


Adds a simple recursive tree command ```usage: tree or tree <dir>``` to the built-in commands and enables directory autocompletion.

Closes #1 